### PR TITLE
feat: Use images for resources with icon fallback

### DIFF
--- a/spa_game.html
+++ b/spa_game.html
@@ -1259,28 +1259,36 @@
                         <div class="resources-section">
                             <!-- Row 1 -->
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="shillings-icon">💷</div>
+                                <div class="resource-icon" id="shillings-icon">
+                                    <img src="img/shillings.png" alt="Scellini" onerror="resourceImageError(this, '💷')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Scellini</div>
                                     <div class="resource-value" id="shillings-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="workers-icon">👷</div>
+                                <div class="resource-icon" id="workers-icon">
+                                    <img src="img/workers.png" alt="Lavoratori" onerror="resourceImageError(this, '👷')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Lavoratori</div>
                                     <div class="resource-value" id="workers-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="wool-icon">🐑</div>
+                                <div class="resource-icon" id="wool-icon">
+                                    <img src="img/wool.png" alt="Lana" onerror="resourceImageError(this, '🐑')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Lana</div>
                                     <div class="resource-value" id="wool-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="whisky-icon">🥃</div>
+                                <div class="resource-icon" id="whisky-icon">
+                                    <img src="img/whisky.png" alt="Whisky" onerror="resourceImageError(this, '🥃')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Whisky</div>
                                     <div class="resource-value" id="whisky-value">0</div>
@@ -1289,28 +1297,36 @@
 
                             <!-- Row 2 -->
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="peat-icon">🧱</div>
+                                <div class="resource-icon" id="peat-icon">
+                                    <img src="img/peat.png" alt="Torba" onerror="resourceImageError(this, '🧱')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Torba</div>
                                     <div class="resource-value" id="peat-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="coal-icon">🔥</div>
+                                <div class="resource-icon" id="coal-icon">
+                                    <img src="img/coal.png" alt="Carbone" onerror="resourceImageError(this, '🔥')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Carbone</div>
                                     <div class="resource-value" id="coal-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="iron-icon">🔩</div>
+                                <div class="resource-icon" id="iron-icon">
+                                    <img src="img/iron.png" alt="Ferro" onerror="resourceImageError(this, '🔩')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Ferro</div>
                                     <div class="resource-value" id="iron-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="fish-icon">🐟</div>
+                                <div class="resource-icon" id="fish-icon">
+                                    <img src="img/fish.png" alt="Pesce" onerror="resourceImageError(this, '🐟')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Pesce</div>
                                     <div class="resource-value" id="fish-value">0</div>
@@ -1319,28 +1335,36 @@
 
                             <!-- Row 3 -->
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="lumber-icon">🪵</div>
+                                <div class="resource-icon" id="lumber-icon">
+                                    <img src="img/lumber.png" alt="Legname" onerror="resourceImageError(this, '🪵')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Legname</div>
                                     <div class="resource-value" id="lumber-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="oats-icon">🌾</div>
+                                <div class="resource-icon" id="oats-icon">
+                                    <img src="img/oats.png" alt="Avena" onerror="resourceImageError(this, '🌾')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Avena</div>
                                     <div class="resource-value" id="oats-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="grain-icon">🌾</div>
+                                <div class="resource-icon" id="grain-icon">
+                                    <img src="img/grain.png" alt="Grano" onerror="resourceImageError(this, '🌾')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Grano</div>
                                     <div class="resource-value" id="grain-value">0</div>
                                 </div>
                             </div>
                             <div class="resource-item">
-                                <div class="resource-icon placeholder" id="cows-icon">🐄</div>
+                                <div class="resource-icon" id="cows-icon">
+                                    <img src="img/cows.png" alt="Mucche" onerror="resourceImageError(this, '🐄')">
+                                </div>
                                 <div class="resource-info">
                                     <div class="resource-label">Mucche</div>
                                     <div class="resource-value" id="cows-value">0</div>
@@ -1412,6 +1436,15 @@
            onchange="handleSavegameFileLoad(event)">
 
     <script>
+        // ================= UI UTILITIES =================
+        function resourceImageError(element, fallbackIcon) {
+            const parent = element.parentElement;
+            if (parent) {
+                parent.innerHTML = fallbackIcon;
+                parent.classList.add('placeholder');
+            }
+        }
+
         // ================= AUDIO MANAGER =================
         class AudioManager {
             constructor() {


### PR DESCRIPTION
This commit updates the `spa_game.html` to display images for each resource in the game UI.

Key changes:
- Replaced hardcoded emoji icons with `<img>` tags.
- Image sources point to an `img/` directory, with filenames corresponding to the resource (e.g., `img/shillings.png`).
- Added a JavaScript function `resourceImageError` that acts as an `onerror` handler for the images. If an image fails to load, this function reverts the element to display the original emoji icon, ensuring the UI remains functional.
- This provides a robust fallback mechanism as requested.