### PR TITLE
fix: Correct modal image styling to be square and contained

### DIFF
--- a/spa_game.html
+++ b/spa_game.html
@@ -875,6 +875,9 @@
             transition: transform 0.3s ease;
             color: white;
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
         .modal-overlay.active .modal-container {
@@ -885,15 +888,13 @@
         .modal-image-container {
             width: 30%;
             aspect-ratio: 1 / 1;
-            margin: -80px auto 20px; /* Margine negativo per portarla più in alto */
+            margin-bottom: 20px;
             background-color: rgba(0, 0, 0, 0.2);
-            border: 2px solid rgba(255, 255, 255, 0.2);
-            border-radius: 50%; /* Cerchio perfetto */
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
             overflow: hidden;
             display: none; /* Nascosto di default, mostrato da JS */
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-            position: relative;
-            z-index: 10;
+            flex-shrink: 0;
         }
 
         .modal-image-container img {


### PR DESCRIPTION
This commit addresses user feedback on the modal image feature. The previous implementation displayed a circular image that popped out of the modal. This has been corrected to meet the new requirements.

- The CSS for `.modal-container` is updated to use flexbox for better alignment of its content.
- The CSS for `.modal-image-container` is changed to ensure the image is a square (with `aspect-ratio: 1/1`) and has rounded corners instead of being a circle.
- The layout is adjusted so the image container is positioned cleanly inside the top-center of the modal, and the modal's height adjusts to fit the image.
- All previous JavaScript changes to support `imageUrl` in modals and game data are included in this commit.