### PR TITLE
feat: Add responsive square image to all modals

### DIFF
--- a/spa_game.html
+++ b/spa_game.html
@@ -1612,13 +1612,9 @@
             console.log('🔧 Callback annulla:', typeof onCancel, onCancel);
             
             // Gestione immagine
-            if (imageUrl) {
-                imageContainer.innerHTML = `<img src="${imageUrl}" alt="Modal Image">`;
-                imageContainer.style.display = 'block';
-            } else {
-                imageContainer.innerHTML = '';
-                imageContainer.style.display = 'none';
-            }
+            const finalImageUrl = imageUrl || 'https://via.placeholder.com/150/808080/FFFFFF?Text=IMG';
+            imageContainer.innerHTML = `<img src="${finalImageUrl}" alt="Modal Image">`;
+            imageContainer.style.display = 'block';
 
             // Imposta contenuto
             titleElement.textContent = title;
@@ -1668,13 +1664,9 @@
             console.log('ℹ️ Mostrando modale informativo:', title);
             
             // Gestione immagine
-            if (imageUrl) {
-                imageContainer.innerHTML = `<img src="${imageUrl}" alt="Modal Image">`;
-                imageContainer.style.display = 'block';
-            } else {
-                imageContainer.innerHTML = '';
-                imageContainer.style.display = 'none';
-            }
+            const finalImageUrl = imageUrl || 'https://via.placeholder.com/150/808080/FFFFFF?Text=IMG';
+            imageContainer.innerHTML = `<img src="${finalImageUrl}" alt="Modal Image">`;
+            imageContainer.style.display = 'block';
 
             // Imposta contenuto
             titleElement.textContent = title;
@@ -1716,13 +1708,9 @@
             console.log('📝 Mostrando modale con input:', title);
 
             // Gestione immagine
-            if (imageUrl) {
-                imageContainer.innerHTML = `<img src="${imageUrl}" alt="Modal Image">`;
-                imageContainer.style.display = 'block';
-            } else {
-                imageContainer.innerHTML = '';
-                imageContainer.style.display = 'none';
-            }
+            const finalImageUrl = imageUrl || 'https://via.placeholder.com/150/808080/FFFFFF?Text=IMG';
+            imageContainer.innerHTML = `<img src="${finalImageUrl}" alt="Modal Image">`;
+            imageContainer.style.display = 'block';
 
             // Imposta contenuto
             titleElement.textContent = title;


### PR DESCRIPTION
This commit introduces a feature to display a responsive, square image at the top of all modal windows.

The implementation includes:
- A new 'modal-image-container' div added to the modal's HTML structure.
- CSS rules to style the image container as a responsive square, ensuring it is always contained within the modal.
- Updates to the `showConfirmModal`, `showInfoModal`, and `showNameInputModal` JavaScript functions. They now accept an `imageUrl` parameter and will display a default placeholder image if no specific URL is provided.
- An update to the "Fuga di Pecore" event in the game data to demonstrate the use of a custom image in a modal.