### PR TITLE
Fix: Rende il pulsante "MUOVITI" sempre cliccabile

### DIFF
--- a/spa_game.html
+++ b/spa_game.html
@@ -2686,14 +2686,10 @@
             moveButton.id = 'btn_move';
             moveButton.className = 'action-button'; // Stile unificato
             moveButton.textContent = 'MUOVITI';
-            moveButton.disabled = true; // Disabilitato di default
+            moveButton.disabled = false; // Abilitato di default
             moveButton.addEventListener('click', handleMove);
             moveButton.addEventListener('mouseenter', () => {
-                if (moveButton.disabled) {
-                    changeNarrativeText('custom', "Devi prima completare un'azione in questa locazione per poterti muovere.");
-                } else {
-                    changeNarrativeText('custom', "Avanza sul tabellone di 1-6 caselle verso una nuova avventura!");
-                }
+                changeNarrativeText('custom', "Avanza sul tabellone di 1-6 caselle verso una nuova avventura!");
             });
             moveButton.addEventListener('mouseleave', () => {
                 changeNarrativeText('base');


### PR DESCRIPTION
In precedenza, il pulsante "MUOVITI" veniva abilitato solo dopo che il giocatore eseguiva un'azione. Questo poteva causare una situazione di stallo se il giocatore non aveva risorse sufficienti per compiere alcuna azione, bloccandolo nel gioco.

Questa modifica rende il pulsante "MUOVITI" abilitato di default al caricamento di una nuova locazione. In questo modo, il giocatore può sempre scegliere di muoversi, anche se non può eseguire altre azioni, risolvendo il bug logico.

È stato aggiornato anche il testo che appare al passaggio del mouse sul pulsante, dato che non sarà più disabilitato.