### PR TITLE
feat: Display image in exit game modal

### DIFF
--- a/spa_game.html
+++ b/spa_game.html
@@ -2323,7 +2323,8 @@
                 // Callback di annullamento.
                 function() {
                     console.log('❌ Uscita annullata');
-                }
+                },
+                'exit_image.png'
             );
         }
 


### PR DESCRIPTION
This change modifies the `exitGame` function to pass an `imageUrl` to the `showConfirmModal` function.

This implements the user's request to show `exit_image.png` when the exit game confirmation dialog is displayed.