### PR TITLE
feat: Implement Hall of Fame screen and set default volume to zero

### DIFF
--- a/spa_game.html
+++ b/spa_game.html
@@ -1575,7 +1575,7 @@
                                    class="volume-slider"
                                    min="0"
                                    max="100"
-                                   value="75"
+                                   value="0"
                                    oninput="changeVolume(this.value)">
                         </div>
                     </div>
@@ -1628,7 +1628,7 @@
                                    class="volume-slider"
                                    min="0"
                                    max="100"
-                                   value="75"
+                                   value="0"
                                    oninput="changeVolume(this.value)">
                         </div>
                     </div>
@@ -1908,7 +1908,7 @@
                                    class="volume-slider" 
                                    min="0" 
                                    max="100" 
-                                   value="75" 
+                                   value="0"
                                    oninput="changeVolume(this.value)">
                         </div>
                     </div>
@@ -2690,7 +2690,7 @@
                     
                     // === IMPOSTAZIONI UTENTE ===
                     settings: {
-                        audio_volume: 75,
+                        audio_volume: 0,
                         is_muted: false,
                         autoSave: true,
                     },


### PR DESCRIPTION
This commit introduces a new Hall of Fame screen and updates the main menu. It also addresses a follow-up request to set the default audio volume to zero.

Changes include:

- **Main Menu Updates:**
  - Renamed "CARICA PARTITA" to "CONTINUA PARTITA".
  - Replaced "OPZIONI" with a "HALL OF FAME" button.
  - Added a volume slider to the main menu footer.

- **New Hall of Fame Screen:**
  - Created a new, fully functional "Hall of Fame" screen with a header, a centered list of top players, a back button, and its own volume slider.

- **Audio Volume Fix:**
  - Set the default `audio_volume` to `0` in the JavaScript `PlayerDataManager`.
  - Updated the default `value` of all three HTML volume sliders to `0` to ensure they start at the minimum value.

- **JavaScript and CSS:**
  - Added `showHallOfFame()` function for navigation.
  - Refactored audio functions to support multiple sliders.
  - Added CSS for styling the Hall of Fame elements.