### PR TITLE
Fix: Synchronize volume slider UI on initial load.

### DIFF
--- a/spa_game.html
+++ b/spa_game.html
@@ -2840,7 +2840,7 @@
                     
                     // === IMPOSTAZIONI UTENTE ===
                     settings: {
-                        audio_volume: 0,
+                        audio_volume: 50,
                         is_muted: false,
                         autoSave: true,
                     },
@@ -4115,6 +4115,10 @@
             // Inizializza con il main menu
             showSection('main-menu-section');
             console.log('🎮 Gioco inizializzato - Menu principale attivo');
+
+            // Inizializza l'UI del volume per sincronizzare lo stato visivo con i dati caricati
+            updateVolumeSlider();
+            updateVolumeIcon();
 
             // Avvia la musica di sottofondo
             // NOTA: Aggiungi qui altri file .mp3 se necessario


### PR DESCRIPTION
- Changed the default audio volume for new users from 0 to 50 to match the intended visual default.
- Added calls to updateVolumeSlider() and updateVolumeIcon() to the page load event listener.
- This ensures the slider's thumb position and the volume bar are correctly synchronized with the audio data from the moment the application starts, fixing the visual inconsistency on all screens.