### PR TITLE
Fix Hall of Fame screen layout

### DIFF
--- a/spa_game.html
+++ b/spa_game.html
@@ -1636,7 +1636,7 @@
         <!-- ================= SEZIONE HALL OF FAME ================= -->
         <div id="hall-of-fame-section" class="spa-section">
             <div class="layout-container">
-                <header class="header-section">
+                <header class="header-section" style="justify-content: center;">
                     <h1 data-text="HALL OF FAME">HALL OF FAME</h1>
                 </header>
                 <main class="main-section" style="justify-content: center;">
@@ -1665,7 +1665,7 @@
                         </ol>
                     </div>
                 </main>
-                <footer class="footer-section">
+                <footer class="footer-section" style="justify-content: space-between;">
                      <div class="footer-left">
                         <button class="back-button" onclick="showSection('main-menu-section')">← BACK TO MAIN MENU</button>
                     </div>


### PR DESCRIPTION
- Centers the "HALL OF FAME" title in the header.
- Aligns the footer elements using 'space-between', moving the "Back to Main Menu" button to the left and the volume controls to the right.

This change aligns the Hall of Fame screen's layout with the Game UI screen, as requested.